### PR TITLE
Fix typo in vfio-menu.py

### DIFF
--- a/scripts/extras/vfio-passthrough.py
+++ b/scripts/extras/vfio-passthrough.py
@@ -129,6 +129,7 @@ vfio_names: list = []
 selected_vfio_ids: list = []
 qemu_flags: list = []
 gpuDetected = 0
+naviDetected = 0
 # Symbol for Lists (because Gigantech got us all f*cked up in the first place and now we can't decide on our UI thingy)
 symbol: str = "》"
 

--- a/scripts/vfio-menu.py
+++ b/scripts/vfio-menu.py
@@ -100,7 +100,7 @@ clear()
 if detectChoice == "1":
     os.system('./scripts/extras/vfio-passthrough.py')
 elif detectChoice == "2":
-    os.system('./scripts/hyperchromatic/usb-passthrough.py')
+    os.system('./scripts/hyperchromiac/usb-passthrough.py')
 elif detectChoice == "3":
     os.system('./scripts/extras/vfio-check.py')
 


### PR DESCRIPTION
I fixed a typo in vfio-menu.py that prevented the USB passthrough option from working.