### PR TITLE
fixed SyntaxWarning when checking gpu compatibility

### DIFF
--- a/scripts/extras/gpu-check.py
+++ b/scripts/extras/gpu-check.py
@@ -79,7 +79,7 @@ def autoRun():
     for x in vgaGrep:
         #val = x.split('[', 1)[1].split(']')
         a = "aaaa"  # aaaaaaaa?
-        val = re.findall('\[.*?\]', x)
+        val = re.findall(r'\[.*?\]', x)
         vgaGrepT.append(val)
     gpuList = open("resources/gpuList.json")
     data = json.load(gpuList)


### PR DESCRIPTION
I get the following SyntaxWarning when visiting the GPU COMPATIBILITY CHECKER:
```
./scripts/extras/gpu-check.py:82: SyntaxWarning: invalid escape sequence '\['
  val = re.findall('\[.*?\]', x)
```

I've seen that in other files a regular expression is represented as raw string, so I used it here too.